### PR TITLE
Fix docstrings for generic quality reporting

### DIFF
--- a/GuideManager/__init__.py
+++ b/GuideManager/__init__.py
@@ -1,5 +1,5 @@
 class GuideManager:
-    """Manages the 8D guide steps and associated resources."""
+    """Manages guide steps and resources for generic quality-report methods."""
 
     def load_guide(self, path):
         """Load guide information from the given path."""

--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -1,5 +1,5 @@
 class ReportGenerator:
-    """Generates 8D reports from analyzed data."""
+    """Generates reports for generic quality-report methods from analyzed data."""
 
     def generate(self, analysis):
         """Return a formatted report from the analysis results."""

--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -1,5 +1,5 @@
 class UI:
-    """Handles user interactions for the 8D Reporter application."""
+    """Handles user interactions and supports generic quality-report methods."""
 
     def start(self):
         """Start the UI. In a full application this might launch a CLI or GUI."""


### PR DESCRIPTION
## Summary
- remove '8D' references from docstrings
- describe use with generic quality-report methods

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68500b0ed85c832fba13457f4a6893ad