### PR TITLE
Add type hints to packages

### DIFF
--- a/Comparison/__init__.py
+++ b/Comparison/__init__.py
@@ -1,6 +1,11 @@
+"""Comparison utilities."""
+
+from typing import Any, Dict
+
+
 class Comparison:
     """Compares different versions of reports or data sets."""
 
-    def compare(self, old, new):
+    def compare(self, old: Any, new: Any) -> Dict[str, Any]:
         """Return differences between the old and new data."""
         return {}

--- a/GuideManager/__init__.py
+++ b/GuideManager/__init__.py
@@ -1,6 +1,11 @@
-class GuideManager:
-    """Manages guide steps and resources for generic quality-report methods."""
+"""Guide management module."""
 
-    def load_guide(self, path):
+from typing import Optional
+
+
+class GuideManager:
+    """Manages guide steps and resources for quality-report methods."""
+
+    def load_guide(self, path: str) -> Optional[dict]:
         """Load guide information from the given path."""
-        pass
+        return None

--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -1,6 +1,11 @@
+"""Module providing analysis via Large Language Models."""
+
+from typing import Dict, Any
+
+
 class LLMAnalyzer:
     """Analyzes text using a Large Language Model."""
 
-    def analyze(self, text):
+    def analyze(self, text: str) -> Dict[str, Any]:
         """Return analysis results for the provided text."""
         return {}

--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -1,6 +1,11 @@
-class ReportGenerator:
-    """Generates reports for generic quality-report methods from analyzed data."""
+"""Report generation utilities."""
 
-    def generate(self, analysis):
+from typing import Dict, Any
+
+
+class ReportGenerator:
+    """Generates reports for quality-report methods from analyzed data."""
+
+    def generate(self, analysis: Dict[str, Any]) -> str:
         """Return a formatted report from the analysis results."""
         return ""

--- a/Review/__init__.py
+++ b/Review/__init__.py
@@ -1,6 +1,11 @@
+"""Review utilities."""
+
+from typing import Iterable, List
+
+
 class Review:
     """Reviews generated reports or analysis results."""
 
-    def perform(self, data):
+    def perform(self, data: Iterable[str]) -> List[str]:
         """Review the given data and return feedback."""
         return []

--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -1,6 +1,11 @@
-class UI:
-    """Handles user interactions and supports generic quality-report methods."""
+"""User interface utilities."""
 
-    def start(self):
+from typing import Optional
+
+
+class UI:
+    """Handles user interactions and supports quality-report methods."""
+
+    def start(self) -> Optional[bool]:
         """Start the UI. In a full application this might launch a CLI or GUI."""
-        pass
+        return None


### PR DESCRIPTION
## Summary
- annotate packages with type hints for public methods
- improve documentation strings

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68500bbe7f88832f9beafcc3c80cc3a0