### PR TITLE
Fix README example to match ReportGenerator API

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,14 @@ guide.load_guide("Guidelines/8D_Guide.json")
 analyzer = LLMAnalyzer()
 analysis = analyzer.analyze(text)
 
-reporter = ReportGenerator()
-pdf_path, excel_path = reporter.generate(analysis)
-print("PDF kaydedildi:", pdf_path)
-print("Excel kaydedildi:", excel_path)
+reporter = ReportGenerator(guide)
+report_path = reporter.generate(analysis)
+print("Rapor olusturuldu:", report_path)
 ```
 
 ## Cikti Formatlari
 
-`ReportGenerator.generate` fonksiyonunun PDF ve Excel dosya yollarini dondurmesi beklenir.
-Raporlar varsayilan olarak calisma dizininde `rapor.pdf` ve `rapor.xlsx` adiyla olusur.
+`ReportGenerator.generate` fonksiyonu olusturulan raporun yolunu dondurur.
+Raporun hangi formata sahip oldugu uygulamanin ilerleyen surumlerinde belirlenecektir.
 
 Simdilik siniflar sadece taslak niteligindedir ve gercek islevler icermemektedir.


### PR DESCRIPTION
## Summary
- update README example to instantiate `ReportGenerator` with a `GuideManager`
- mention that `generate()` returns a single report path instead of PDF and Excel paths

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_6850241ac510832fac5cb1e523059907