### PR TITLE
Add report generator output to PDF and Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ analyzer = LLMAnalyzer()
 analysis = analyzer.analyze(text)
 
 reporter = ReportGenerator(guide)
-report_path = reporter.generate(analysis)
-print("Rapor olusturuldu:", report_path)
+paths = reporter.generate(analysis, "raporlar")
+print("PDF yolu:", paths["pdf"])
+print("Excel yolu:", paths["excel"])
 ```
 
 ## Cikti Formatlari
 
-`ReportGenerator.generate` fonksiyonu olusturulan raporun yolunu dondurur.
-Raporun hangi formata sahip oldugu uygulamanin ilerleyen surumlerinde belirlenecektir.
+`ReportGenerator.generate` fonksiyonu olusturulan PDF ve Excel dosyalarinin yolunu dondurur.
 
 Simdilik siniflar sadece taslak niteligindedir ve gercek islevler icermemektedir.

--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Dict, Any
+from typing import Any, Dict
+from pathlib import Path
+
+from fpdf import FPDF
+from openpyxl import Workbook
 
 from GuideManager import GuideManager
 
@@ -18,6 +22,44 @@ class ReportGenerator:
         """Return a report template for the given method."""
         return self.guide_manager.get_format(method)
 
-    def generate(self, analysis: Dict[str, Any]) -> str:
-        """Return a formatted report from the analysis results."""
-        return ""
+    def generate(self, analysis: Dict[str, Any], output_dir: str | Path = ".") -> Dict[str, str]:
+        """Create PDF and Excel reports from the analysis results.
+
+        Parameters
+        ----------
+        analysis: Dict[str, Any]
+            The analysis data returned from ``LLMAnalyzer``.
+        output_dir: str | Path, optional
+            Directory in which to save the generated files.
+
+        Returns
+        -------
+        Dict[str, str]
+            A dictionary containing the generated PDF and Excel file paths.
+        """
+
+        out_dir = Path(output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        pdf_path = out_dir / "report.pdf"
+        excel_path = out_dir / "report.xlsx"
+
+        # Create PDF
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.cell(0, 10, txt="Analysis Report", ln=1)
+        for key, value in analysis.items():
+            line = f"{key}: {value.get('response', '')}"
+            pdf.multi_cell(0, 10, txt=line)
+        pdf.output(str(pdf_path))
+
+        # Create Excel
+        wb = Workbook()
+        ws = wb.active
+        ws.append(["Step", "Response"])
+        for key, value in analysis.items():
+            ws.append([key, value.get("response", "")])
+        wb.save(str(excel_path))
+
+        return {"pdf": str(pdf_path), "excel": str(excel_path)}

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,0 +1,27 @@
+import tempfile
+from pathlib import Path
+import unittest
+
+from GuideManager import GuideManager
+from ReportGenerator import ReportGenerator
+
+
+class ReportGeneratorTest(unittest.TestCase):
+    """Tests for ReportGenerator.generate."""
+
+    def setUp(self) -> None:
+        self.manager = GuideManager()
+        self.generator = ReportGenerator(self.manager)
+
+    def test_generate_creates_files(self) -> None:
+        analysis = {"Step1": {"response": "foo"}, "Step2": {"response": "bar"}}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = self.generator.generate(analysis, tmpdir)
+            pdf_path = Path(paths["pdf"])
+            excel_path = Path(paths["excel"])
+            self.assertTrue(pdf_path.exists())
+            self.assertTrue(excel_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement PDF and Excel generation in `ReportGenerator.generate`
- return generated file paths
- document the output format in `README`
- add unit test for `ReportGenerator`

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6850263ba8ac832f87c05ee39be4bb62