### PR TITLE
Add pytest cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 
 # Misc
 *.log
+.pytest_cache/


### PR DESCRIPTION
## Summary
- avoid committing pytest's cache by ignoring `.pytest_cache/`

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685027a4a480832fba099a8561917b50