### PR TITLE
Add tests for analyzer fallback and template generation

### DIFF
--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -18,6 +18,11 @@ class LLMAnalyzerTest(unittest.TestCase):
         for value in result.values():
             self.assertIn("response", value)
 
+    def test_query_llm_fallback(self) -> None:
+        """``_query_llm`` should return a placeholder when OpenAI fails."""
+        result = self.analyzer._query_llm("prompt")
+        self.assertTrue(result.startswith("LLM response placeholder"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,6 +1,7 @@
 import tempfile
 from pathlib import Path
 import unittest
+from unittest.mock import patch
 
 from GuideManager import GuideManager
 from ReportGenerator import ReportGenerator
@@ -21,6 +22,16 @@ class ReportGeneratorTest(unittest.TestCase):
             excel_path = Path(paths["excel"])
             self.assertTrue(pdf_path.exists())
             self.assertTrue(excel_path.exists())
+
+    def test_generate_template_uses_manager(self) -> None:
+        """``generate_template`` should fetch the correct format via ``GuideManager``."""
+        expected = {"fields": []}
+        method = "8D"
+        with patch.object(GuideManager, "get_format", return_value=expected) as mock_get:
+            generator = ReportGenerator(self.manager)
+            result = generator.generate_template(method)
+            mock_get.assert_called_with(method)
+            self.assertEqual(result, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `LLMAnalyzer` tests with fallback behaviour
- ensure `ReportGenerator.generate_template` delegates to `GuideManager`

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68502816f17c832f83362b83f7bfdfda