### PR TITLE
Enhance complaint detail support

### DIFF
--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -33,16 +33,25 @@ class LLMAnalyzer:
             # Fallback for offline or missing API key
             return f"LLM response placeholder for: {prompt[:50]}"
 
-    def analyze(self, complaint_text: str, guideline: Dict[str, Any]) -> Dict[str, Any]:
-        """Return analysis results per guideline step for the complaint text."""
+    def analyze(self, details: Dict[str, Any], guideline: Dict[str, Any]) -> Dict[str, Any]:
+        """Return analysis results per guideline step using complaint details."""
+        complaint_text = details.get("complaint", "")
+        customer = details.get("customer", "")
+        subject = details.get("subject", "")
+        part_code = details.get("part_code", "")
+
         results: Dict[str, Any] = {}
         fields = guideline.get("fields", [])
         for step in fields:
             step_id = step.get("id", "unknown")
             definition = step.get("definition", "")
             prompt = (
-                f"Analyze the following complaint according to step '{step_id}'.\n"
-                f"Step definition: {definition}\nComplaint: {complaint_text}"
+                f"Analyze according to step '{step_id}'.\n"
+                f"Step definition: {definition}\n"
+                f"Customer: {customer}\n"
+                f"Subject: {subject}\n"
+                f"Part code: {part_code}\n"
+                f"Complaint: {complaint_text}"
             )
             answer = self._query_llm(prompt)
             results[step_id] = {"response": answer}

--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -22,13 +22,20 @@ class ReportGenerator:
         """Return a report template for the given method."""
         return self.guide_manager.get_format(method)
 
-    def generate(self, analysis: Dict[str, Any], output_dir: str | Path = ".") -> Dict[str, str]:
+    def generate(
+        self,
+        analysis: Dict[str, Any],
+        details: Dict[str, str],
+        output_dir: str | Path = ".",
+    ) -> Dict[str, str]:
         """Create PDF and Excel reports from the analysis results.
 
         Parameters
         ----------
         analysis: Dict[str, Any]
             The analysis data returned from ``LLMAnalyzer``.
+        details: Dict[str, str]
+            Complaint details such as customer and subject.
         output_dir: str | Path, optional
             Directory in which to save the generated files.
 
@@ -49,6 +56,10 @@ class ReportGenerator:
         pdf.add_page()
         pdf.set_font("Arial", size=12)
         pdf.cell(0, 10, txt="Analysis Report", ln=1)
+        for key, value in details.items():
+            label = key.replace("_", " ").title()
+            pdf.cell(0, 10, txt=f"{label}: {value}", ln=1)
+        pdf.ln(5)
         for key, value in analysis.items():
             line = f"{key}: {value.get('response', '')}"
             pdf.multi_cell(0, 10, txt=line)
@@ -57,6 +68,10 @@ class ReportGenerator:
         # Create Excel
         wb = Workbook()
         ws = wb.active
+        for key, value in details.items():
+            label = key.replace("_", " ").title()
+            ws.append([label, value])
+        ws.append([])
         ws.append(["Step", "Response"])
         for key, value in analysis.items():
             ws.append([key, value.get("response", "")])

--- a/UI/cli.py
+++ b/UI/cli.py
@@ -20,6 +20,9 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--complaint", "-c", help="Complaint text")
     parser.add_argument("--method", "-m", choices=METHODS, help="Reporting method")
     parser.add_argument("--output", "-o", default="reports", help="Output directory")
+    parser.add_argument("--customer", help="Customer name")
+    parser.add_argument("--subject", help="Complaint subject")
+    parser.add_argument("--part-code", help="Related part code")
     return parser.parse_args(args)
 
 
@@ -29,15 +32,24 @@ def main(args: Optional[List[str]] = None) -> None:
 
     complaint = options.complaint or input("Complaint text: ")
     method = options.method or input(f"Method ({', '.join(METHODS)}): ")
+    customer = options.customer or input("Customer: ")
+    subject = options.subject or input("Subject: ")
+    part_code = options.part_code or input("Part code: ")
 
     manager = GuideManager()
     guideline = manager.get_format(method)
 
     analyzer = LLMAnalyzer()
-    analysis = analyzer.analyze(complaint, guideline)
+    details = {
+        "complaint": complaint,
+        "customer": customer,
+        "subject": subject,
+        "part_code": part_code,
+    }
+    analysis = analyzer.analyze(details, guideline)
 
     generator = ReportGenerator(manager)
-    paths = generator.generate(analysis, options.output)
+    paths = generator.generate(analysis, details, options.output)
 
     print(json.dumps(analysis, indent=2, ensure_ascii=False))
     print(f"PDF report: {paths['pdf']}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,20 @@ class CLITest(unittest.TestCase):
         }
 
         with io.StringIO() as buf, redirect_stdout(buf):
-            cli.main(["--complaint", "c", "--method", "8D", "--output", "out"])
+            cli.main([
+                "--complaint",
+                "c",
+                "--method",
+                "8D",
+                "--output",
+                "out",
+                "--customer",
+                "cust",
+                "--subject",
+                "subject",
+                "--part-code",
+                "code",
+            ])
             output = buf.getvalue()
 
         self.assertIn("Step1", output)

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -13,7 +13,13 @@ class LLMAnalyzerTest(unittest.TestCase):
 
     @patch.object(LLMAnalyzer, "_query_llm", return_value="answer")
     def test_analyze_returns_keys(self, mock_query) -> None:  # type: ignore
-        result = self.analyzer.analyze("text", self.guideline)
+        details = {
+            "complaint": "text",
+            "customer": "cust",
+            "subject": "subj",
+            "part_code": "code",
+        }
+        result = self.analyzer.analyze(details, self.guideline)
         self.assertEqual(set(result.keys()), {"Step1", "Step2"})
         for value in result.values():
             self.assertIn("response", value)

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -16,8 +16,9 @@ class ReportGeneratorTest(unittest.TestCase):
 
     def test_generate_creates_files(self) -> None:
         analysis = {"Step1": {"response": "foo"}, "Step2": {"response": "bar"}}
+        details = {"complaint": "c", "customer": "cust", "subject": "sub", "part_code": "code"}
         with tempfile.TemporaryDirectory() as tmpdir:
-            paths = self.generator.generate(analysis, tmpdir)
+            paths = self.generator.generate(analysis, details, tmpdir)
             pdf_path = Path(paths["pdf"])
             excel_path = Path(paths["excel"])
             self.assertTrue(pdf_path.exists())


### PR DESCRIPTION
## Summary
- extend CLI to accept customer, subject and part code
- prompt for these fields when missing
- adjust `LLMAnalyzer.analyze` to use a details dictionary
- include complaint details at top of reports
- update tests for new arguments and parameters

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685031c7fa00832f99e73579507970ac