### PR TITLE
Update ReportGenerator interface for complaint info

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ analyzer = LLMAnalyzer()
 analysis = analyzer.analyze(text)
 
 reporter = ReportGenerator(guide)
-paths = reporter.generate(analysis, "raporlar")
+info = {"customer": "ACME", "subject": "Issue", "part_code": "X"}
+paths = reporter.generate(analysis, info, "raporlar")
 print("PDF yolu:", paths["pdf"])
 print("Excel yolu:", paths["excel"])
 ```

--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -25,7 +25,7 @@ class ReportGenerator:
     def generate(
         self,
         analysis: Dict[str, Any],
-        details: Dict[str, str],
+        complaint_info: Dict[str, str],
         output_dir: str | Path = ".",
     ) -> Dict[str, str]:
         """Create PDF and Excel reports from the analysis results.
@@ -34,8 +34,8 @@ class ReportGenerator:
         ----------
         analysis: Dict[str, Any]
             The analysis data returned from ``LLMAnalyzer``.
-        details: Dict[str, str]
-            Complaint details such as customer and subject.
+        complaint_info: Dict[str, str]
+            Information about the complaint such as customer, subject and part code.
         output_dir: str | Path, optional
             Directory in which to save the generated files.
 
@@ -56,9 +56,12 @@ class ReportGenerator:
         pdf.add_page()
         pdf.set_font("Arial", size=12)
         pdf.cell(0, 10, txt="Analysis Report", ln=1)
-        for key, value in details.items():
-            label = key.replace("_", " ").title()
-            pdf.cell(0, 10, txt=f"{label}: {value}", ln=1)
+        customer = complaint_info.get("customer", "")
+        subject = complaint_info.get("subject", "")
+        part_code = complaint_info.get("part_code", "")
+        pdf.cell(0, 10, txt=f"Customer: {customer}", ln=1)
+        pdf.cell(0, 10, txt=f"Subject: {subject}", ln=1)
+        pdf.cell(0, 10, txt=f"Part Code: {part_code}", ln=1)
         pdf.ln(5)
         for key, value in analysis.items():
             line = f"{key}: {value.get('response', '')}"
@@ -68,9 +71,9 @@ class ReportGenerator:
         # Create Excel
         wb = Workbook()
         ws = wb.active
-        for key, value in details.items():
-            label = key.replace("_", " ").title()
-            ws.append([label, value])
+        ws.append(["Customer", customer])
+        ws.append(["Subject", subject])
+        ws.append(["Part Code", part_code])
         ws.append([])
         ws.append(["Step", "Response"])
         for key, value in analysis.items():

--- a/UI/cli.py
+++ b/UI/cli.py
@@ -48,8 +48,14 @@ def main(args: Optional[List[str]] = None) -> None:
     }
     analysis = analyzer.analyze(details, guideline)
 
+    complaint_info = {
+        "customer": customer,
+        "subject": subject,
+        "part_code": part_code,
+    }
+
     generator = ReportGenerator(manager)
-    paths = generator.generate(analysis, details, options.output)
+    paths = generator.generate(analysis, complaint_info, options.output)
 
     print(json.dumps(analysis, indent=2, ensure_ascii=False))
     print(f"PDF report: {paths['pdf']}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,17 @@ class CLITest(unittest.TestCase):
         self.assertIn("file.pdf", output)
         mock_manager.return_value.get_format.assert_called_with("8D")
         mock_analyzer.return_value.analyze.assert_called_once()
-        mock_report.return_value.generate.assert_called_once()
+        mock_report.return_value.generate.assert_called_with(
+            {
+                "Step1": {"response": "ok"},
+            },
+            {
+                "customer": "cust",
+                "subject": "subject",
+                "part_code": "code",
+            },
+            "out",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -16,9 +16,9 @@ class ReportGeneratorTest(unittest.TestCase):
 
     def test_generate_creates_files(self) -> None:
         analysis = {"Step1": {"response": "foo"}, "Step2": {"response": "bar"}}
-        details = {"complaint": "c", "customer": "cust", "subject": "sub", "part_code": "code"}
+        info = {"customer": "cust", "subject": "sub", "part_code": "code"}
         with tempfile.TemporaryDirectory() as tmpdir:
-            paths = self.generator.generate(analysis, details, tmpdir)
+            paths = self.generator.generate(analysis, info, tmpdir)
             pdf_path = Path(paths["pdf"])
             excel_path = Path(paths["excel"])
             self.assertTrue(pdf_path.exists())


### PR DESCRIPTION
## Summary
- modify `ReportGenerator.generate` to take `complaint_info`
- prepend customer, subject and part code to report outputs
- update CLI and unit tests for new API
- adjust README example

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685032a3c948832f927b3f5fab5714f9