### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -1,7 +1,8 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+import types
 
-from LLMAnalyzer import LLMAnalyzer
+from LLMAnalyzer import LLMAnalyzer, OpenAIError
 
 
 class LLMAnalyzerTest(unittest.TestCase):
@@ -25,9 +26,33 @@ class LLMAnalyzerTest(unittest.TestCase):
             self.assertIn("response", value)
 
     def test_query_llm_fallback(self) -> None:
-        """``_query_llm`` should return a placeholder when OpenAI fails."""
-        result = self.analyzer._query_llm("prompt")
+        """``_query_llm`` should return a placeholder for non-auth errors."""
+        mock_openai = types.ModuleType("openai")
+        mock_openai.ChatCompletion = MagicMock()
+        mock_openai.ChatCompletion.create.side_effect = Exception("network")
+        with patch.dict("sys.modules", {"openai": mock_openai}):
+            with patch.dict("os.environ", {"OPENAI_API_KEY": "key"}):
+                result = self.analyzer._query_llm("prompt")
         self.assertTrue(result.startswith("LLM response placeholder"))
+
+    def test_missing_api_key_raises(self) -> None:
+        """Missing ``OPENAI_API_KEY`` should raise ``OpenAIError``."""
+        mock_openai = types.ModuleType("openai")
+        mock_openai.ChatCompletion = MagicMock()
+        with patch.dict("sys.modules", {"openai": mock_openai}):
+            with patch.dict("os.environ", {}, clear=True):
+                with self.assertRaises(OpenAIError):
+                    self.analyzer._query_llm("prompt")
+
+    def test_invalid_api_key_raises(self) -> None:
+        """Invalid API key should raise ``OpenAIError``."""
+        mock_openai = types.ModuleType("openai")
+        mock_openai.ChatCompletion = MagicMock()
+        mock_openai.ChatCompletion.create.side_effect = Exception("invalid api key")
+        with patch.dict("sys.modules", {"openai": mock_openai}):
+            with patch.dict("os.environ", {"OPENAI_API_KEY": "bad"}):
+                with self.assertRaises(OpenAIError):
+                    self.analyzer._query_llm("prompt")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a dedicated `OpenAIError` exception
- raise that exception for missing package or API key
- surface invalid API key errors
- expand unit tests for these cases

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_685034485e70832f94798114fad6bdc4