### PR TITLE
Lazy load CLI module

### DIFF
--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -1,8 +1,17 @@
 """User interface utilities."""
 
-from typing import Optional
+from typing import List, Optional
 
-from .cli import main as run_cli
+
+def run_cli(args: Optional[List[str]] = None) -> None:
+    """Run the CLI application with optional ``args``.
+
+    The CLI module is imported lazily to avoid the overhead at package import
+    time.
+    """
+    from .cli import main
+
+    main(args)
 
 
 class UI:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class UILazyImportTest(unittest.TestCase):
+    """Tests for lazy CLI import and UI.start."""
+
+    def setUp(self) -> None:
+        # Ensure a clean import state
+        sys.modules.pop('UI', None)
+        sys.modules.pop('UI.cli', None)
+        self.UI = importlib.import_module('UI')
+
+    def test_cli_not_imported_on_package_import(self) -> None:
+        self.assertNotIn('UI.cli', sys.modules)
+
+    def test_run_cli_imports_cli(self) -> None:
+        dummy_cli = types.ModuleType('UI.cli')
+        dummy_cli.main = MagicMock()
+        with patch.dict(sys.modules, {'UI.cli': dummy_cli}):
+            self.UI.run_cli()
+            dummy_cli.main.assert_called_once()
+
+    def test_start_invokes_run_cli(self) -> None:
+        with patch.object(self.UI, 'run_cli') as mock_run:
+            ui = self.UI.UI()
+            ui.start()
+            mock_run.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- make the CLI import lazy in `UI.__init__`
- test that `run_cli` imports the CLI only when called
- verify that `UI.start` delegates to `run_cli`

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685039a341e8832f91bd9873cfbc2398