### PR TITLE
Fix README minimal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ from ReportGenerator import ReportGenerator
 text = "musteri sikayet metni"
 
 guide = GuideManager()
-guide.load_guide("Guidelines/8D_Guide.json")
+guideline = guide.get_format("8D")
 
 analyzer = LLMAnalyzer()
-analysis = analyzer.analyze(text)
+details = {"complaint": text}
+analysis = analyzer.analyze(details, guideline)
 
 reporter = ReportGenerator(guide)
 info = {"customer": "ACME", "subject": "Issue", "part_code": "X"}


### PR DESCRIPTION
## Summary
- update README minimal example to use `details` dict

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_68503d4c1228832f8f535a9fa7e7a99b