### PR TITLE
Add Streamlit UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ ui = UI()
 ui.start()
 ```
 
+## Streamlit Arayuzu
+
+Tarayici tabanli arayuzu calistirmak icin asagidaki komutu kullanabilirsiniz:
+
+```bash
+streamlit run -m UI.streamlit_app
+```
+
+Python kodu icinden `run_streamlit()` fonksiyonunu da cagirabilirsiniz:
+
+```python
+from UI import run_streamlit
+
+run_streamlit()
+```
+
 ## Minimal Ornek
 
 Asagidaki kod ornegi girdi akisini nasil kullanabileceginizi gosterir:

--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -3,6 +3,13 @@
 from typing import List, Optional
 
 
+def run_streamlit() -> None:
+    """Run the Streamlit application."""
+    from . import streamlit_app
+
+    streamlit_app.main()
+
+
 def run_cli(args: Optional[List[str]] = None) -> None:
     """Run the CLI application with optional ``args``.
 
@@ -23,4 +30,4 @@ class UI:
         return None
 
 
-__all__ = ["UI", "run_cli"]
+__all__ = ["UI", "run_cli", "run_streamlit"]

--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -1,0 +1,60 @@
+"""Streamlit interface for Quality Reporter."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from GuideManager import GuideManager
+from LLMAnalyzer import LLMAnalyzer
+from ReportGenerator import ReportGenerator
+
+METHODS = ["8D", "5N1K", "A3", "DMAIC", "Ishikawa"]
+
+
+def main() -> None:
+    """Run the Streamlit application."""
+    st.title("Quality Reporter")
+
+    complaint = st.text_area("Complaint")
+    method = st.selectbox("Method", METHODS)
+    customer = st.text_input("Customer")
+    subject = st.text_input("Subject")
+    part_code = st.text_input("Part code")
+
+    if st.button("Analyze"):
+        manager = GuideManager()
+        guideline = manager.get_format(method)
+
+        analyzer = LLMAnalyzer()
+        details: dict[str, str] = {
+            "complaint": complaint,
+            "customer": customer,
+            "subject": subject,
+            "part_code": part_code,
+        }
+        with st.spinner("Analyzing..."):
+            analysis = analyzer.analyze(details, guideline)
+
+        complaint_info = {
+            "customer": customer,
+            "subject": subject,
+            "part_code": part_code,
+        }
+        generator = ReportGenerator(manager)
+        paths = generator.generate(analysis, complaint_info, "reports")
+
+        st.subheader("Analysis")
+        st.json(analysis)
+
+        with open(paths["pdf"], "rb") as pdf_file:
+            st.download_button("Download PDF", pdf_file, file_name="report.pdf")
+
+        with open(paths["excel"], "rb") as excel_file:
+            st.download_button("Download Excel", excel_file, file_name="report.xlsx")
+
+        st.markdown(f"[PDF file]({paths['pdf']})")
+        st.markdown(f"[Excel file]({paths['excel']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1,0 +1,59 @@
+import importlib
+import sys
+import types
+import unittest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch, mock_open
+
+
+class StreamlitAppTest(unittest.TestCase):
+    """Tests for the Streamlit UI."""
+
+    def setUp(self) -> None:
+        dummy_st = types.ModuleType("streamlit")
+        dummy_st.title = MagicMock()
+        dummy_st.text_area = MagicMock(return_value="c")
+        dummy_st.selectbox = MagicMock(return_value="8D")
+        dummy_st.text_input = MagicMock(side_effect=["cust", "subject", "code"])
+        dummy_st.button = MagicMock(return_value=True)
+        dummy_st.subheader = MagicMock()
+        dummy_st.json = MagicMock()
+        dummy_st.download_button = MagicMock()
+        dummy_st.markdown = MagicMock()
+
+        @contextmanager
+        def spinner(*args, **kwargs):
+            yield
+
+        dummy_st.spinner = spinner
+        sys.modules["streamlit"] = dummy_st
+        self.dummy_st = dummy_st
+
+    def tearDown(self) -> None:
+        sys.modules.pop("streamlit", None)
+
+    def test_main_pipeline(self) -> None:
+        module = importlib.import_module("UI.streamlit_app")
+        with patch.object(module, "GuideManager") as mock_manager, \
+             patch.object(module, "LLMAnalyzer") as mock_analyzer, \
+             patch.object(module, "ReportGenerator") as mock_report, \
+             patch("builtins.open", mock_open(read_data=b"data")):
+            mock_manager.return_value.get_format.return_value = {"fields": []}
+            mock_analyzer.return_value.analyze.return_value = {
+                "Step1": {"response": "ok"}
+            }
+            mock_report.return_value.generate.return_value = {
+                "pdf": "file.pdf",
+                "excel": "file.xlsx",
+            }
+
+            module.main()
+
+            mock_manager.return_value.get_format.assert_called_with("8D")
+            mock_analyzer.return_value.analyze.assert_called_once()
+            mock_report.return_value.generate.assert_called_once()
+            self.assertTrue(self.dummy_st.download_button.called)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement simple Streamlit interface
- expose `run_streamlit()` helper in `UI`
- document web app usage in README
- test new Streamlit app with mocked Streamlit API

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68507311ff30832fa42eeec2040b62e2