### PR TITLE
Read OPENAI_MODEL from env

### DIFF
--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -13,8 +13,14 @@ class OpenAIError(RuntimeError):
 class LLMAnalyzer:
     """Analyzes text using a Large Language Model."""
 
-    def __init__(self, model: str = "gpt-3.5-turbo") -> None:
-        """Initialize the analyzer with an optional LLM model name."""
+    def __init__(self, model: str | None = None) -> None:
+        """Initialize the analyzer with an optional LLM model name.
+
+        If ``model`` is ``None``, ``OPENAI_MODEL`` environment variable is used.
+        When the variable is not set, ``"gpt-3.5-turbo"`` becomes the default.
+        """
+        if model is None:
+            model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
         self.model = model
 
     def _query_llm(self, prompt: str) -> str:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ export OPENAI_API_KEY="sk-..."
 Gecerli bir anahtar saglanmadiginda veya baglanti kurulamazsa analiz
 sonuclari icin yer tutucu metinler dondurulur.
 
+`OPENAI_MODEL` degiskenini `.env` dosyanizda ya da dogrudan ortamda
+tanimlayarak kullanilacak model adini belirleyebilirsiniz. Deger
+verilmezse varsayilan `gpt-3.5-turbo` kullanilir.
+
 ## Modul Yapisi
 
 Proje asagidaki paketleri icermektedir:

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -54,6 +54,12 @@ class LLMAnalyzerTest(unittest.TestCase):
                 with self.assertRaises(OpenAIError):
                     self.analyzer._query_llm("prompt")
 
+    def test_init_uses_openai_model_env(self) -> None:
+        """Default model should come from ``OPENAI_MODEL`` env variable."""
+        with patch.dict("os.environ", {"OPENAI_MODEL": "gpt-test"}):
+            analyzer = LLMAnalyzer()
+        self.assertEqual(analyzer.model, "gpt-test")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- let `LLMAnalyzer` take the model from the `OPENAI_MODEL` environment variable when no argument is given
- note that `.env` can supply `OPENAI_MODEL`
- add a unit test for the `OPENAI_MODEL` environment variable

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685076ae3de4832fa8b29222f7abbe02