### PR TITLE
Generate unique report filenames

### DIFF
--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from fpdf import FPDF
 from openpyxl import Workbook
+from uuid import uuid4
 
 from GuideManager import GuideManager
 
@@ -48,8 +49,9 @@ class ReportGenerator:
         out_dir = Path(output_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
 
-        pdf_path = out_dir / "report.pdf"
-        excel_path = out_dir / "report.xlsx"
+        unique_id = uuid4().hex
+        pdf_path = out_dir / f"report_{unique_id}.pdf"
+        excel_path = out_dir / f"report_{unique_id}.xlsx"
 
         # Create PDF
         pdf = FPDF()

--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import streamlit as st
 
+from pathlib import Path
 from GuideManager import GuideManager
 from LLMAnalyzer import LLMAnalyzer
 from ReportGenerator import ReportGenerator
@@ -46,11 +47,13 @@ def main() -> None:
         st.subheader("Analysis")
         st.json(analysis)
 
+        pdf_name = Path(paths["pdf"]).name
         with open(paths["pdf"], "rb") as pdf_file:
-            st.download_button("Download PDF", pdf_file, file_name="report.pdf")
+            st.download_button("Download PDF", pdf_file, file_name=pdf_name)
 
+        excel_name = Path(paths["excel"]).name
         with open(paths["excel"], "rb") as excel_file:
-            st.download_button("Download Excel", excel_file, file_name="report.xlsx")
+            st.download_button("Download Excel", excel_file, file_name=excel_name)
 
         st.markdown(f"[PDF file]({paths['pdf']})")
         st.markdown(f"[Excel file]({paths['excel']})")

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -24,6 +24,16 @@ class ReportGeneratorTest(unittest.TestCase):
             self.assertTrue(pdf_path.exists())
             self.assertTrue(excel_path.exists())
 
+    def test_generate_unique_paths(self) -> None:
+        """Consecutive calls should produce different file names."""
+        analysis = {"Step1": {"response": "foo"}}
+        info = {"customer": "c"}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            first = self.generator.generate(analysis, info, tmpdir)
+            second = self.generator.generate(analysis, info, tmpdir)
+            self.assertNotEqual(first["pdf"], second["pdf"])
+            self.assertNotEqual(first["excel"], second["excel"])
+
     def test_generate_template_uses_manager(self) -> None:
         """``generate_template`` should fetch the correct format via ``GuideManager``."""
         expected = {"fields": []}


### PR DESCRIPTION
## Summary
- add uuid filenames to ReportGenerator output
- show generated filenames in Streamlit download buttons
- test that filenames are unique on repeated calls

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_685077429120832faba9925bb507d3ec