### PR TITLE
Add run_app entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Tarayici tabanli arayuzu calistirmak icin asagidaki komutu kullanabilirsiniz:
 streamlit run -m UI.streamlit_app
 ```
 
+Kok dizindeki ``run_app.py`` dosyasi ayni arayuzu kolayca acmanizi saglar:
+
+```bash
+python run_app.py
+```
+
 Python kodu icinden `run_streamlit()` fonksiyonunu da cagirabilirsiniz:
 
 ```python

--- a/run_app.py
+++ b/run_app.py
@@ -1,0 +1,12 @@
+"""Convenience script to launch the Streamlit interface."""
+
+from UI import run_streamlit
+
+
+def main() -> None:
+    """Execute the Streamlit UI."""
+    run_streamlit()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1,0 +1,17 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class RunAppTest(unittest.TestCase):
+    """Tests for the ``run_app`` entry point."""
+
+    def test_main_invokes_run_streamlit(self) -> None:
+        module = importlib.import_module("run_app")
+        with patch.object(module, "run_streamlit") as mock_run:
+            module.main()
+            mock_run.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `run_app.py` to launch Streamlit UI with a single command
- document usage of the new launcher in the README
- test the new `run_app` module

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6850867a3b00832fa3dd2971dd93c336