### PR TITLE
Improve Streamlit launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,13 @@ Tarayici tabanli arayuzu calistirmak icin asagidaki komutu kullanabilirsiniz:
 streamlit run -m UI.streamlit_app
 ```
 
-Kok dizindeki ``run_app.py`` dosyasi ayni arayuzu kolayca acmanizi saglar:
+Kok dizindeki ``run_app.py`` dosyasi ayni arayuzu kolayca ve uyarisiz sekilde acmanizi saglar:
 
 ```bash
 python run_app.py
 ```
+
+Bu komut arayuzu hicbir uyari gormeden baslatir.
 
 Python kodu icinden `run_streamlit()` fonksiyonunu da cagirabilirsiniz:
 

--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -4,10 +4,11 @@ from typing import List, Optional
 
 
 def run_streamlit() -> None:
-    """Run the Streamlit application."""
+    """Start the Streamlit UI."""
     from . import streamlit_app
+    from streamlit.web import bootstrap
 
-    streamlit_app.main()
+    bootstrap.run(streamlit_app.main, "", [], [])
 
 
 def run_cli(args: Optional[List[str]] = None) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fpdf
 openpyxl
 openai
-streamlit
+streamlit>=1.0

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -31,5 +31,27 @@ class UILazyImportTest(unittest.TestCase):
             mock_run.assert_called_once()
 
 
+class RunStreamlitTest(unittest.TestCase):
+    """Tests for ``run_streamlit``."""
+
+    def test_run_streamlit_invokes_bootstrap(self) -> None:
+        module = importlib.import_module("UI")
+
+        dummy_bootstrap = types.ModuleType("streamlit.web.bootstrap")
+        dummy_bootstrap.run = MagicMock()
+        dummy_web = types.ModuleType("streamlit.web")
+        dummy_web.bootstrap = dummy_bootstrap
+        dummy_streamlit = types.ModuleType("streamlit")
+        dummy_streamlit.web = dummy_web
+
+        with patch.dict(sys.modules, {
+            "streamlit": dummy_streamlit,
+            "streamlit.web": dummy_web,
+            "streamlit.web.bootstrap": dummy_bootstrap,
+        }), patch.object(module, "streamlit_app") as mock_app:
+            module.run_streamlit()
+            dummy_bootstrap.run.assert_called_once_with(mock_app.main, "", [], [])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- use `streamlit.web.bootstrap.run` when starting the Streamlit UI
- pin Streamlit version in requirements
- clarify README instructions for `run_app.py`
- test that `run_streamlit` calls `streamlit.web.bootstrap.run`

## Testing
- `pip install -q -r requirements.txt`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68508ac4d8b4832f8464bfefe33ad52b