### PR TITLE
Fix Streamlit launch

### DIFF
--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -8,7 +8,10 @@ def run_streamlit() -> None:
     from . import streamlit_app
     from streamlit.web import bootstrap
 
-    bootstrap.run(streamlit_app.main, "", [], [])
+    # ``bootstrap.run`` expects the path to the Streamlit application
+    # rather than the function object itself. Passing the path prevents
+    # ``TypeError`` issues when ``bootstrap`` tries to modify ``sys.path``.
+    bootstrap.run(streamlit_app.__file__, "", [], [])
 
 
 def run_cli(args: Optional[List[str]] = None) -> None:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -49,8 +49,11 @@ class RunStreamlitTest(unittest.TestCase):
             "streamlit.web": dummy_web,
             "streamlit.web.bootstrap": dummy_bootstrap,
         }), patch.object(module, "streamlit_app") as mock_app:
+            mock_app.__file__ = "app_file"
             module.run_streamlit()
-            dummy_bootstrap.run.assert_called_once_with(mock_app.main, "", [], [])
+            dummy_bootstrap.run.assert_called_once_with(
+                "app_file", "", [], []
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- pass the app path to `bootstrap.run` instead of the main function
- adjust unit test to match new call

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68508c14f68c832f83508f2a961c22ff