### PR TITLE
Fix streamlit run call

### DIFF
--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -11,7 +11,11 @@ def run_streamlit() -> None:
     # ``bootstrap.run`` expects the path to the Streamlit application
     # rather than the function object itself. Passing the path prevents
     # ``TypeError`` issues when ``bootstrap`` tries to modify ``sys.path``.
-    bootstrap.run(streamlit_app.__file__, "", [], [])
+    # ``bootstrap.run`` expects the path to the Streamlit application and a
+    # boolean ``is_hello`` flag in recent Streamlit versions. Passing ``False``
+    # avoids ``TypeError`` issues when the underlying implementation assumes a
+    # boolean value.
+    bootstrap.run(streamlit_app.__file__, False, [], [])
 
 
 def run_cli(args: Optional[List[str]] = None) -> None:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -52,7 +52,7 @@ class RunStreamlitTest(unittest.TestCase):
             mock_app.__file__ = "app_file"
             module.run_streamlit()
             dummy_bootstrap.run.assert_called_once_with(
-                "app_file", "", [], []
+                "app_file", False, [], []
             )
 
 


### PR DESCRIPTION
## Summary
- fix `run_streamlit` to send a boolean for `bootstrap.run`
- update tests for the new call

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68508dcd31f4832f9ae632eb6ab8e2da