### PR TITLE
Add Unicode font support to ReportGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ pip install -r requirements.txt
 ```
 
 Bu komut arayuz icin gerekli streamlit kutuphanesini de kurar.
+Unicode karakterleri iceren PDF ciktisi icin
+`/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` yolunda bulunan DejaVu Sans
+TTF dosyasinin kurulmus olmasi gerekir.
 ## OpenAI Anahtari
 
 `LLMAnalyzer` sinifi OpenAI API'sini kullanir. Gercek bir sorgu icin

--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -56,7 +56,10 @@ class ReportGenerator:
         # Create PDF
         pdf = FPDF()
         pdf.add_page()
-        pdf.set_font("Arial", size=12)
+        # Register a Unicode font for non-Latin characters
+        font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+        pdf.add_font("DejaVu", "", font_path, uni=True)
+        pdf.set_font("DejaVu", size=12)
         pdf.cell(0, 10, txt="Analysis Report", ln=1)
         customer = complaint_info.get("customer", "")
         subject = complaint_info.get("subject", "")

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -34,6 +34,15 @@ class ReportGeneratorTest(unittest.TestCase):
             self.assertNotEqual(first["pdf"], second["pdf"])
             self.assertNotEqual(first["excel"], second["excel"])
 
+    def test_generate_handles_unicode(self) -> None:
+        """PDF creation should not fail with non-Latin characters."""
+        analysis = {"Adım1": {"response": "İşlem tamam"}}
+        info = {"customer": "Müşteri", "subject": "Konu", "part_code": "K001"}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = self.generator.generate(analysis, info, tmpdir)
+            self.assertTrue(Path(paths["pdf"]).exists())
+            self.assertTrue(Path(paths["excel"]).exists())
+
     def test_generate_template_uses_manager(self) -> None:
         """``generate_template`` should fetch the correct format via ``GuideManager``."""
         expected = {"fields": []}


### PR DESCRIPTION
## Summary
- register DejaVu Sans font in `ReportGenerator.generate`
- mention required TTF file in README
- test PDF generation with non-Latin characters

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_685090183e6c832f9060dea93f852a2b