### PR TITLE
Use local DejaVu font

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Bu komut arayuz icin gerekli streamlit kutuphanesini de kurar.
-Unicode karakterleri iceren PDF ciktisi icin
-`/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` yolunda bulunan DejaVu Sans
-TTF dosyasinin kurulmus olmasi gerekir.
+Bu komut arayüz için gerekli ``streamlit`` kütüphanesini de kurar.
+Unicode karakterleri içeren PDF çıktısı alınabilmesi için depo kökünde bulunan
+``Fonts`` klasöründeki ``DejaVuSans.ttf`` dosyası kullanılır. Dosya mevcut
+değilse sistemdeki ``/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf`` yolu
+denenir.
 ## OpenAI Anahtari
 
 `LLMAnalyzer` sinifi OpenAI API'sini kullanir. Gercek bir sorgu icin

--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -57,8 +57,10 @@ class ReportGenerator:
         pdf = FPDF()
         pdf.add_page()
         # Register a Unicode font for non-Latin characters
-        font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
-        pdf.add_font("DejaVu", "", font_path, uni=True)
+        font_path = Path(__file__).resolve().parents[1] / "Fonts" / "DejaVuSans.ttf"
+        if not font_path.exists():
+            font_path = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+        pdf.add_font("DejaVu", "", str(font_path), uni=True)
         pdf.set_font("DejaVu", size=12)
         pdf.cell(0, 10, txt="Analysis Report", ln=1)
         customer = complaint_info.get("customer", "")


### PR DESCRIPTION
## Summary
- use `Fonts/DejaVuSans.ttf` by default when generating PDFs
- update README with information about the new font location

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_68509407c6ac832fa81703dc0559d008