### PR TITLE
Load env vars from dotenv file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ denenir.
 ## OpenAI Anahtari
 
 `LLMAnalyzer` sinifi OpenAI API'sini kullanir. Gercek bir sorgu icin
-`OPENAI_API_KEY` ortam degiskenini asagidaki gibi tanimlayin:
+`OPENAI_API_KEY` ortam degiskenini asagidaki gibi tanimlayin veya ayni
+isimli degiskeni `.env` dosyaniza ekleyin. Uygulama baslatildiginda dosya
+varsa otomatik olarak yuklenir:
 
 ```bash
 export OPENAI_API_KEY="sk-..."

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fpdf
 openpyxl
 openai
 streamlit>=1.0
+python-dotenv

--- a/run_app.py
+++ b/run_app.py
@@ -1,6 +1,12 @@
 """Convenience script to launch the Streamlit interface."""
 
+from __future__ import annotations
+
+from dotenv import load_dotenv
+
 from UI import run_streamlit
+
+load_dotenv()
 
 
 def main() -> None:

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -7,7 +7,9 @@ class RunAppTest(unittest.TestCase):
     """Tests for the ``run_app`` entry point."""
 
     def test_main_invokes_run_streamlit(self) -> None:
-        module = importlib.import_module("run_app")
+        with patch("dotenv.load_dotenv") as mock_load:
+            module = importlib.import_module("run_app")
+        mock_load.assert_called_once()
         with patch.object(module, "run_streamlit") as mock_run:
             module.main()
             mock_run.assert_called_once()


### PR DESCRIPTION
## Summary
- automatically load variables from `.env` on start
- document that `.env` values are read automatically
- require `python-dotenv`
- update test to expect `load_dotenv` call

## Testing
- `python -m pip install -q -r requirements.txt`
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_68509d9ed04c832fb407647c750e46fb