### PR TITLE
Update to new OpenAI API

### DIFF
--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -27,24 +27,24 @@ class LLMAnalyzer:
         """Return the LLM response for the given prompt."""
         print("LLMAnalyzer._query_llm start")
         try:
-            import openai  # type: ignore
+            from openai import OpenAI  # type: ignore
         except ImportError as exc:  # pragma: no cover - import errors not expected
             raise OpenAIError("openai package is not installed") from exc
 
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise OpenAIError("OPENAI_API_KEY not set")
-        openai.api_key = api_key
+        client = OpenAI(api_key=api_key)
 
         try:
-            response = openai.ChatCompletion.create(
+            response = client.chat.completions.create(
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
             )
             tokens = getattr(getattr(response, "usage", None), "total_tokens", None)
             if tokens is not None:
                 print(f"LLMAnalyzer tokens used: {tokens}")
-            result = response.choices[0].message["content"].strip()
+            result = response.choices[0].message.content.strip()
             print("LLMAnalyzer._query_llm end")
             return result
         except Exception as exc:  # pragma: no cover - network issues

--- a/Review/__init__.py
+++ b/Review/__init__.py
@@ -30,24 +30,24 @@ class Review:
         """Return the LLM response for the given prompt."""
         print("Review._query_llm start")
         try:
-            import openai  # type: ignore
+            from openai import OpenAI  # type: ignore
         except ImportError as exc:  # pragma: no cover - optional dependency
             raise ReviewLLMError("openai package is not installed") from exc
 
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise ReviewLLMError("OPENAI_API_KEY not set")
-        openai.api_key = api_key
+        client = OpenAI(api_key=api_key)
 
         try:
-            response = openai.ChatCompletion.create(
+            response = client.chat.completions.create(
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
             )
             tokens = getattr(getattr(response, "usage", None), "total_tokens", None)
             if tokens is not None:
                 print(f"Review tokens used: {tokens}")
-            result = response.choices[0].message["content"].strip()
+            result = response.choices[0].message.content.strip()
             print("Review._query_llm end")
             return result
         except Exception as exc:  # pragma: no cover - network issues

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -30,9 +30,10 @@ class ReviewTest(unittest.TestCase):
         with patch("builtins.open", mock_open(read_data=template)):
             review = Review()
         mock_openai = types.ModuleType("openai")
-        mock_openai.ChatCompletion = MagicMock()
+        mock_client = MagicMock()
         exc = Exception("timeout")
-        mock_openai.ChatCompletion.create.side_effect = exc
+        mock_client.chat.completions.create.side_effect = exc
+        mock_openai.OpenAI = MagicMock(return_value=mock_client)
         with patch.dict("sys.modules", {"openai": mock_openai}):
             with patch.dict("os.environ", {"OPENAI_API_KEY": "key"}):
                 with patch("builtins.print") as mock_print:
@@ -47,12 +48,12 @@ class ReviewTest(unittest.TestCase):
         mock_openai = types.ModuleType("openai")
         usage = types.SimpleNamespace(total_tokens=3)
         response = types.SimpleNamespace(
-            choices=[types.SimpleNamespace(message={"content": "rev"})],
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="rev"))],
             usage=usage,
         )
-        mock_chat = MagicMock()
-        mock_chat.create.return_value = response
-        mock_openai.ChatCompletion = mock_chat
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = response
+        mock_openai.OpenAI = MagicMock(return_value=mock_client)
         with patch.dict("sys.modules", {"openai": mock_openai}):
             with patch.dict("os.environ", {"OPENAI_API_KEY": "key"}):
                 with patch("builtins.print") as mock_print:


### PR DESCRIPTION
## Summary
- switch from `openai.ChatCompletion.create` to the new `OpenAI` client
- adjust Review and LLMAnalyzer modules for the new interface
- update tests to mock the new client

## Testing
- `pip install fpdf openpyxl streamlit python-dotenv`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6850a33a7edc832f921eb82efcf1b452