### PR TITLE
Integrate PromptManager and update analyzer

### DIFF
--- a/PromptManager/__init__.py
+++ b/PromptManager/__init__.py
@@ -1,0 +1,22 @@
+"""Utilities for loading prompt templates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+class PromptManager:
+    """Manages LLM prompt templates."""
+
+    def load_prompt(self, path: str) -> Dict[str, Any]:
+        """Load a prompt template from ``path``."""
+        with open(path, "r", encoding="utf-8") as file:
+            return json.load(file)
+
+    def get_template(self, method: str) -> Dict[str, Any]:
+        """Return the prompt template for ``method``."""
+        base_dir = Path(__file__).resolve().parents[1] / "Prompts"
+        prompt_path = base_dir / f"{method}_Prompt.json"
+        return self.load_prompt(str(prompt_path))

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+import unittest
+
+from PromptManager import PromptManager
+
+
+class PromptManagerTest(unittest.TestCase):
+    """Tests for PromptManager template loading."""
+
+    def setUp(self) -> None:
+        self.manager = PromptManager()
+        self.base_dir = Path(__file__).resolve().parents[1] / "Prompts"
+
+    def test_get_template(self) -> None:
+        for method in ["5N1K", "8D", "A3", "DMAIC", "Ishikawa"]:
+            with self.subTest(method=method):
+                expected_path = self.base_dir / f"{method}_Prompt.json"
+                with open(expected_path, "r", encoding="utf-8") as f:
+                    expected = json.load(f)
+                result = self.manager.get_template(method)
+                self.assertEqual(result, expected)
+
+    def test_load_prompt(self) -> None:
+        test_file = self.base_dir / "8D_Prompt.json"
+        with open(test_file, "r", encoding="utf-8") as f:
+            expected = json.load(f)
+        result = self.manager.load_prompt(str(test_file))
+        self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `PromptManager` helper for JSON prompt templates
- use `PromptManager` inside `LLMAnalyzer.analyze`
- adjust analyzer tests and add new tests for prompt templates

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6850b52ce47c832f92feee86379acb32