### PR TITLE
Fix UI streamlit patching in tests

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -48,7 +48,7 @@ class RunStreamlitTest(unittest.TestCase):
             "streamlit": dummy_streamlit,
             "streamlit.web": dummy_web,
             "streamlit.web.bootstrap": dummy_bootstrap,
-        }), patch.object(module, "streamlit_app") as mock_app:
+        }), patch("UI.streamlit_app", create=True) as mock_app:
             mock_app.__file__ = "app_file"
             module.run_streamlit()
             dummy_bootstrap.run.assert_called_once_with(


### PR DESCRIPTION
## Summary
- update `RunStreamlitTest` to patch `UI.streamlit_app` using `patch("UI.streamlit_app", create=True)`
- avoid AttributeError when patching `streamlit_app`

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_6850b78d1e4c832fb32aa5b7b0e22158