### PR TITLE
Refactor review step into single call

### DIFF
--- a/Review/__init__.py
+++ b/Review/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Iterable, List
 
 
 class ReviewLLMError(RuntimeError):
@@ -69,10 +68,7 @@ class Review:
         }
         return self.template.format(**params)
 
-    def perform(self, data: Iterable[str], **context: str) -> List[str]:
-        """Review the given data and return feedback for each item."""
-        results: List[str] = []
-        for text in data:
-            prompt = self._build_prompt(text, **context)
-            results.append(self._query_llm(prompt))
-        return results
+    def perform(self, text: str, **context: str) -> str:
+        """Return a reviewed version of the provided ``text``."""
+        prompt = self._build_prompt(text, **context)
+        return self._query_llm(prompt)

--- a/UI/cli.py
+++ b/UI/cli.py
@@ -56,16 +56,16 @@ def main(args: Optional[List[str]] = None) -> None:
         json.dump(analysis, f, ensure_ascii=False, indent=2)
 
     reviewer = Review()
-    reviewed = reviewer.perform(
-        [value["response"] for value in analysis.values()],
+    combined = "\n".join(v["response"] for v in analysis.values())
+    full_report = reviewer.perform(
+        combined,
         method=method,
         customer=customer,
         subject=subject,
         part_code=part_code,
         guideline_json=json.dumps(guideline, ensure_ascii=False),
     )
-    for (key, value), new_resp in zip(analysis.items(), reviewed):
-        value["response"] = new_resp
+    analysis["full_report"] = {"response": full_report}
 
     with open(out_dir / "LLM2.txt", "w", encoding="utf-8") as f:
         json.dump(analysis, f, ensure_ascii=False, indent=2)

--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -43,16 +43,16 @@ def main() -> None:
             json.dump(analysis, f, ensure_ascii=False, indent=2)
         with st.spinner("Rapor değerlendiriliyor..."):
             reviewer = Review()
-            reviewed = reviewer.perform(
-                [v["response"] for v in analysis.values()],
+            combined = "\n".join(v["response"] for v in analysis.values())
+            full_report = reviewer.perform(
+                combined,
                 method=method,
                 customer=customer,
                 subject=subject,
                 part_code=part_code,
                 guideline_json=json.dumps(guideline, ensure_ascii=False),
             )
-            for (key, value), new_resp in zip(analysis.items(), reviewed):
-                value["response"] = new_resp
+            analysis["full_report"] = {"response": full_report}
         with open(out_dir / "LLM2.txt", "w", encoding="utf-8") as f:
             json.dump(analysis, f, ensure_ascii=False, indent=2)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ class CLITest(unittest.TestCase):
         mock_analyzer.return_value.analyze.return_value = {
             "Step1": {"response": "ok"}
         }
-        mock_review.return_value.perform.return_value = ["checked"]
+        mock_review.return_value.perform.return_value = "checked"
         mock_report.return_value.generate.return_value = {
             "pdf": "file.pdf",
             "excel": "file.xlsx",
@@ -54,7 +54,7 @@ class CLITest(unittest.TestCase):
         mock_manager.return_value.get_format.assert_called_with("8D")
         mock_analyzer.return_value.analyze.assert_called_once()
         mock_review.return_value.perform.assert_called_with(
-            ["ok"],
+            "ok",
             method="8D",
             customer="cust",
             subject="subject",
@@ -63,7 +63,8 @@ class CLITest(unittest.TestCase):
         )
         mock_report.return_value.generate.assert_called_with(
             {
-                "Step1": {"response": "checked"},
+                "Step1": {"response": "ok"},
+                "full_report": {"response": "checked"},
             },
             {
                 "customer": "cust",

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -10,10 +10,10 @@ class ReviewTest(unittest.TestCase):
 
     def test_perform_uses_query_llm(self) -> None:
         review = Review()
-        with patch.object(Review, "_query_llm", side_effect=["a", "b"]) as mock_query:
-            result = review.perform(["x", "y"])
-            self.assertEqual(result, ["a", "b"])
-            self.assertEqual(mock_query.call_count, 2)
+        with patch.object(Review, "_query_llm", return_value="a") as mock_query:
+            result = review.perform("x")
+            self.assertEqual(result, "a")
+            mock_query.assert_called_once()
 
     def test_prompt_template_is_used(self) -> None:
         template = "prefix {initial_report_text} suffix"
@@ -21,7 +21,7 @@ class ReviewTest(unittest.TestCase):
             review = Review()
         with patch.object(Review, "_query_llm") as mock_query:
             mock_query.return_value = "ok"
-            review.perform(["data"])
+            review.perform("data")
             mock_query.assert_called_with("prefix data suffix")
 
     def test_query_llm_logs_error(self) -> None:

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -46,7 +46,7 @@ class StreamlitAppTest(unittest.TestCase):
             mock_analyzer.return_value.analyze.return_value = {
                 "Step1": {"response": "ok"}
             }
-            mock_review.return_value.perform.return_value = ["checked"]
+            mock_review.return_value.perform.return_value = "checked"
             mock_report.return_value.generate.return_value = {
                 "pdf": "file.pdf",
                 "excel": "file.xlsx",
@@ -60,7 +60,7 @@ class StreamlitAppTest(unittest.TestCase):
             mock_manager.return_value.get_format.assert_called_with("8D")
             mock_analyzer.return_value.analyze.assert_called_once()
             mock_review.return_value.perform.assert_called_with(
-                ["ok"],
+                "ok",
                 method="8D",
                 customer="cust",
                 subject="subject",
@@ -68,7 +68,10 @@ class StreamlitAppTest(unittest.TestCase):
                 guideline_json=json.dumps({"fields": []}, ensure_ascii=False),
             )
             mock_report.return_value.generate.assert_called_with(
-                {"Step1": {"response": "checked"}},
+                {
+                    "Step1": {"response": "ok"},
+                    "full_report": {"response": "checked"},
+                },
                 {"customer": "cust", "subject": "subject", "part_code": "code"},
                 "reports",
             )


### PR DESCRIPTION
## Summary
- update `Review.perform` to work on a single text block
- concatenate analysis results in CLI and Streamlit before review
- save the reviewed text as a new `full_report` field
- adjust unit tests for the new workflow

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_68512db7931c832f9392c44e7711a2ec