### PR TITLE
Improve Comparison diff and add tests

### DIFF
--- a/Comparison/__init__.py
+++ b/Comparison/__init__.py
@@ -1,11 +1,36 @@
 """Comparison utilities."""
 
-from typing import Any, Dict
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import difflib
+import json
 
 
 class Comparison:
     """Compares different versions of reports or data sets."""
 
-    def compare(self, old: Any, new: Any) -> Dict[str, Any]:
-        """Return differences between the old and new data."""
-        return {}
+    def _to_lines(self, data: Any) -> List[str]:
+        """Return ``data`` as a list of strings for diffing."""
+        if isinstance(data, str):
+            return data.splitlines()
+        if isinstance(data, dict):
+            text = json.dumps(data, sort_keys=True, indent=2)
+            return text.splitlines()
+        return str(data).splitlines()
+
+    def compare(self, old: Any, new: Any) -> Dict[str, List[str]]:
+        """Return added and removed lines between ``old`` and ``new``."""
+        old_lines = self._to_lines(old)
+        new_lines = self._to_lines(new)
+        diff = difflib.unified_diff(old_lines, new_lines, lineterm="")
+
+        added: List[str] = []
+        removed: List[str] = []
+        for line in diff:
+            if line.startswith("+") and not line.startswith("+++"):
+                added.append(line[1:])
+            elif line.startswith("-") and not line.startswith("---"):
+                removed.append(line[1:])
+
+        return {"added": added, "removed": removed}

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,0 +1,27 @@
+import unittest
+
+from Comparison import Comparison
+
+
+class ComparisonTest(unittest.TestCase):
+    """Tests for the Comparison utilities."""
+
+    def setUp(self) -> None:
+        self.comp = Comparison()
+
+    def test_compare_strings(self) -> None:
+        result = self.comp.compare("a\nb", "a\nc")
+        self.assertEqual(result["added"], ["c"])
+        self.assertEqual(result["removed"], ["b"])
+
+    def test_compare_dicts(self) -> None:
+        old = {"a": 1, "b": 2}
+        new = {"a": 1, "b": 3, "c": 4}
+        result = self.comp.compare(old, new)
+        self.assertIn('  "b": 3,', result["added"])  # note trailing comma from JSON
+        self.assertIn('  "c": 4', result["added"])
+        self.assertIn('  "b": 2', result["removed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -46,7 +46,7 @@ class LLMAnalyzerTest(unittest.TestCase):
         self.analyzer.analyze(details, guideline)
         system_prompt, user_prompt = mock_query.call_args[0]
         self.assertIn("D1", system_prompt)
-        self.assertIn("yaln", system_prompt)
+        self.assertIn("SADECE", system_prompt)
 
     @patch.object(LLMAnalyzer, "_query_llm", return_value="ok")
     def test_analyze_uses_prompt_template(self, mock_query) -> None:  # type: ignore


### PR DESCRIPTION
## Summary
- implement Comparison.compare to show unified diffs
- adjust analyzer test for updated prompt
- add unit tests for Comparison

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685137c1d964832f9bc4712b696f4760