### PR TITLE
Move dotenv loading inside main

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -6,11 +6,9 @@ from dotenv import load_dotenv
 
 from UI import run_streamlit
 
-load_dotenv()
-
-
 def main() -> None:
     """Execute the Streamlit UI."""
+    load_dotenv()
     run_streamlit()
 
 

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -9,9 +9,11 @@ class RunAppTest(unittest.TestCase):
     def test_main_invokes_run_streamlit(self) -> None:
         with patch("dotenv.load_dotenv") as mock_load:
             module = importlib.import_module("run_app")
-        mock_load.assert_called_once()
-        with patch.object(module, "run_streamlit") as mock_run:
+        mock_load.assert_not_called()
+        with patch.object(module, "load_dotenv") as mock_load, \
+                patch.object(module, "run_streamlit") as mock_run:
             module.main()
+            mock_load.assert_called_once()
             mock_run.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- load .env vars at runtime rather than import time
- update tests for new behaviour

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685138c4d800832f83ba8701c6579278