### PR TITLE
Cache prompts in PromptManager

### DIFF
--- a/PromptManager/__init__.py
+++ b/PromptManager/__init__.py
@@ -10,16 +10,22 @@ from typing import Any, Dict
 class PromptManager:
     """Manages LLM prompt templates."""
 
+    def __init__(self) -> None:
+        """Initialize the template cache."""
+        self._cache: Dict[str, Dict[str, Any]] = {}
+
     def load_prompt(self, path: str) -> Dict[str, Any]:
         """Load a prompt template from ``path``."""
         with open(path, "r", encoding="utf-8") as file:
             return json.load(file)
 
     def get_template(self, method: str) -> Dict[str, Any]:
-        """Return the prompt template for ``method``."""
-        base_dir = Path(__file__).resolve().parents[1] / "Prompts"
-        prompt_path = base_dir / f"{method}_Prompt.json"
-        return self.load_prompt(str(prompt_path))
+        """Return the prompt template for ``method`` with caching."""
+        if method not in self._cache:
+            base_dir = Path(__file__).resolve().parents[1] / "Prompts"
+            prompt_path = base_dir / f"{method}_Prompt.json"
+            self._cache[method] = self.load_prompt(str(prompt_path))
+        return self._cache[method]
 
     def get_8d_step_prompt(
         self,

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 import unittest
+import unittest.mock
 
 from PromptManager import PromptManager
 
@@ -27,6 +28,21 @@ class PromptManagerTest(unittest.TestCase):
             expected = json.load(f)
         result = self.manager.load_prompt(str(test_file))
         self.assertEqual(result, expected)
+
+    def test_get_template_caches_result(self) -> None:
+        """Repeated calls should not reopen the template file."""
+        test_file = self.base_dir / "8D_Prompt.json"
+        with open(test_file, "r", encoding="utf-8") as f:
+            data = f.read()
+
+        with unittest.mock.patch(
+            "builtins.open", unittest.mock.mock_open(read_data=data)
+        ) as mocked_open:
+            first = self.manager.get_template("8D")
+            second = self.manager.get_template("8D")
+
+            self.assertEqual(mocked_open.call_count, 1)
+            self.assertIs(first, second)
 
     def test_get_8d_step_prompt_truncates_previous(self) -> None:
         """Long previous results should be truncated in the user prompt."""


### PR DESCRIPTION
## Summary
- cache loaded templates in `PromptManager.get_template`
- reuse cached `8D` prompt in `get_8d_step_prompt`
- add unit test confirming caching behavior

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_b_685144ade608832faef15b5295614087