### PR TITLE
Add caching for guide formats

### DIFF
--- a/GuideManager/__init__.py
+++ b/GuideManager/__init__.py
@@ -10,6 +10,10 @@ from typing import Dict, Any
 class GuideManager:
     """Manages guide steps and resources for quality-report methods."""
 
+    def __init__(self) -> None:
+        """Initialize the guide cache."""
+        self._cache: Dict[str, Dict[str, Any]] = {}
+
     def load_guide(self, path: str) -> Dict[str, Any]:
         """Load guide information from the given path."""
         with open(path, "r", encoding="utf-8") as file:
@@ -17,6 +21,8 @@ class GuideManager:
 
     def get_format(self, method: str) -> Dict[str, Any]:
         """Return the guide dictionary for the given method."""
-        base_dir = Path(__file__).resolve().parents[1] / "Guidelines"
-        guide_path = base_dir / f"{method}_Guide.json"
-        return self.load_guide(str(guide_path))
+        if method not in self._cache:
+            base_dir = Path(__file__).resolve().parents[1] / "Guidelines"
+            guide_path = base_dir / f"{method}_Guide.json"
+            self._cache[method] = self.load_guide(str(guide_path))
+        return self._cache[method]

--- a/tests/test_guide_manager.py
+++ b/tests/test_guide_manager.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 import unittest
+import unittest.mock
 
 from GuideManager import GuideManager
 
@@ -27,6 +28,21 @@ class GuideManagerTest(unittest.TestCase):
             expected = json.load(f)
         result = self.manager.load_guide(str(test_file))
         self.assertEqual(result, expected)
+
+    def test_get_format_caches_result(self) -> None:
+        """Repeated calls should not reopen the guideline file."""
+        test_file = self.base_dir / "8D_Guide.json"
+        with open(test_file, "r", encoding="utf-8") as f:
+            data = f.read()
+
+        with unittest.mock.patch(
+            "builtins.open", unittest.mock.mock_open(read_data=data)
+        ) as mocked_open:
+            first = self.manager.get_format("8D")
+            second = self.manager.get_format("8D")
+
+            self.assertEqual(mocked_open.call_count, 1)
+            self.assertIs(first, second)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- cache guideline JSON in `GuideManager`
- test that guideline files aren't reopened after the first load

## Testing
- `python -m unittest tests.test_guide_manager`
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'fpdf')*

------
https://chatgpt.com/codex/tasks/task_b_685145e30af0832fb29092b6bb48ca3b