### PR TITLE
Remove redundant return

### DIFF
--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -35,7 +35,6 @@ class UI:
     def start(self) -> None:
         """Start the CLI."""
         run_cli()
-        return None
 
 
 __all__ = ["UI", "run_cli", "run_streamlit"]


### PR DESCRIPTION
## Summary
- clean up UI.start by dropping an unnecessary `return None`

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6851478b5e90832fa794207fb73f1a80