### PR TITLE
Declare module exports

### DIFF
--- a/Comparison/__init__.py
+++ b/Comparison/__init__.py
@@ -34,3 +34,6 @@ class Comparison:
                 removed.append(line[1:])
 
         return {"added": added, "removed": removed}
+
+
+__all__ = ["Comparison"]

--- a/GuideManager/__init__.py
+++ b/GuideManager/__init__.py
@@ -123,3 +123,6 @@ class GuideManager:
                 else:
                     raise
         return self._cache[method]
+
+
+__all__ = ["GuideManager", "GuideNotFoundError", "DEFAULT_8D_GUIDE"]

--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -153,3 +153,6 @@ class LLMAnalyzer:
             accumulated[step_id] = answer
 
         return results
+
+
+__all__ = ["LLMAnalyzer", "OpenAIError", "DEFAULT_8D_PROMPT"]

--- a/PromptManager/__init__.py
+++ b/PromptManager/__init__.py
@@ -64,3 +64,6 @@ class PromptManager:
             user_prompt = f"{user_prompt}\n\nPrevious step results:\n{joined}"
 
         return system_prompt, user_prompt
+
+
+__all__ = ["PromptManager"]

--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -100,3 +100,6 @@ class ReportGenerator:
         wb.save(str(excel_path))
 
         return {"pdf": str(pdf_path), "excel": str(excel_path)}
+
+
+__all__ = ["ReportGenerator"]

--- a/Review/__init__.py
+++ b/Review/__init__.py
@@ -74,3 +74,6 @@ class Review:
         """Return a reviewed version of the provided ``text``."""
         prompt = self._build_prompt(text, **context)
         return self._query_llm(prompt)
+
+
+__all__ = ["Review", "ReviewLLMError"]


### PR DESCRIPTION
## Summary
- add `__all__` lists to package roots for explicit public API
- keep unit tests passing

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68516102cba4832f904d9498d27edb9a