### PR TITLE
Improve 8D prompt handling

### DIFF
--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -141,8 +141,9 @@ class LLMAnalyzer:
                     user_prompt += f"\n{step_tmpl.format(**values)}"
             else:
                 if method == "8D":
-                    system_prompt = DEFAULT_8D_PROMPT
-                    user_prompt = DEFAULT_8D_PROMPT
+                    system_prompt, user_prompt = prompt_manager.get_8d_step_prompt(
+                        step_id, values, accumulated
+                    )
                 else:
                     step_entry = template.get(step_id, {})
                     system_prompt = step_entry.get("system", "").format(**values)

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -45,8 +45,9 @@ class LLMAnalyzerTest(unittest.TestCase):
         details = {"complaint": "issue"}
         self.analyzer.analyze(details, guideline)
         system_prompt, user_prompt = mock_query.call_args[0]
-        self.assertEqual(system_prompt, DEFAULT_8D_PROMPT)
-        self.assertEqual(user_prompt, DEFAULT_8D_PROMPT)
+        self.assertIn("D1", system_prompt)
+        self.assertIn("Müşteri Şikayeti: issue", user_prompt)
+        self.assertIn("Açıklama: issue", user_prompt)
 
     @patch.object(LLMAnalyzer, "_query_llm", return_value="ok")
     def test_analyze_uses_prompt_template(self, mock_query) -> None:  # type: ignore
@@ -61,8 +62,9 @@ class LLMAnalyzerTest(unittest.TestCase):
         }
         self.analyzer.analyze(details, guideline)
         system_prompt, user_prompt = mock_query.call_args_list[0][0]
-        self.assertEqual(system_prompt, DEFAULT_8D_PROMPT)
-        self.assertEqual(user_prompt, DEFAULT_8D_PROMPT)
+        self.assertIn("D1", system_prompt)
+        self.assertIn("c", user_prompt)
+        self.assertIn("code", user_prompt)
 
     @patch.object(LLMAnalyzer, "_query_llm")
     def test_previous_results_included(self, mock_query) -> None:  # type: ignore
@@ -79,10 +81,10 @@ class LLMAnalyzerTest(unittest.TestCase):
         first_call = mock_query.call_args_list[0][0]
         second_call = mock_query.call_args_list[1][0]
 
-        self.assertEqual(first_call[0], DEFAULT_8D_PROMPT)
-        self.assertEqual(first_call[1], DEFAULT_8D_PROMPT)
-        self.assertEqual(second_call[0], DEFAULT_8D_PROMPT)
-        self.assertEqual(second_call[1], DEFAULT_8D_PROMPT)
+        self.assertIn("D1", first_call[0])
+        self.assertIn("D2", second_call[0])
+        self.assertIn("Previous step results", second_call[1])
+        self.assertIn("first", second_call[1])
 
     def test_query_llm_fallback(self) -> None:
         """``_query_llm`` should return a placeholder for non-auth errors."""


### PR DESCRIPTION
## Summary
- fill 8D prompts using PromptManager instead of the generic template
- check that formatted prompts contain complaint details in tests

## Testing
- `python -m unittest tests.test_llm_analyzer -v`
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_68516a6955e4832fade584988a53be42