### PR TITLE
Add contributor testing note and setup metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Simdilik siniflar sadece taslak niteligindedir ve gercek islevler icermemektedir
 
 Testler `fpdf`, `openpyxl` ve `python-dotenv` gibi ek paketlere baglidir.
 Bu kutuphaneler `requirements.txt` dosyasinda listelenmistir.
-Testleri calistirmadan once tum bagimliliklari kurdugunuzdan emin olun:
+Katkida bulunacak gelistiriciler, testleri calistirmadan once asagidaki komutla tum bagimliliklari kurmalidir:
 
 ```bash
 pip install -r requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = quality-reporter
+version = 0.0.0
+
+[options]
+install_requires =
+    fpdf
+    openpyxl
+    openai
+    streamlit>=1.0
+    python-dotenv


### PR DESCRIPTION
## Summary
- highlight `pip install -r requirements.txt` for contributors in README
- provide `setup.cfg` with dependencies for packaging tools

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68517e9a2748832fb621eb7230fae12a