### PR TITLE
Fix handling of string values in analysis

### DIFF
--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -83,7 +83,8 @@ class ReportGenerator:
         pdf.cell(0, 10, txt=f"Part Code: {part_code}", ln=1)
         pdf.ln(5)
         for key, value in analysis.items():
-            line = f"{key}: {value.get('response', '')}"
+            response = value.get("response", "") if isinstance(value, dict) else str(value)
+            line = f"{key}: {response}"
             width = getattr(pdf, "epw", 0)
             pdf.multi_cell(width, 10, txt=line)
         pdf.output(str(pdf_path))
@@ -97,7 +98,8 @@ class ReportGenerator:
         ws.append([])
         ws.append(["Step", "Response"])
         for key, value in analysis.items():
-            ws.append([key, value.get("response", "")])
+            response = value.get("response", "") if isinstance(value, dict) else str(value)
+            ws.append([key, response])
         wb.save(str(excel_path))
 
         return {"pdf": str(pdf_path), "excel": str(excel_path)}

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -111,6 +111,15 @@ class ReportGeneratorTest(unittest.TestCase):
 
         self.assertIn(dummy.epw, dummy.logged_widths)
 
+    def test_generate_accepts_string_values(self) -> None:
+        """String values in analysis should be handled gracefully."""
+        analysis = {"summary": "ok", "Step": {"response": "foo"}}
+        info = {"customer": "c"}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = self.generator.generate(analysis, info, tmpdir)
+            self.assertTrue(Path(paths["pdf"]).exists())
+            self.assertTrue(Path(paths["excel"]).exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle plain string entries in ReportGenerator.generate
- test that generator can process analysis dicts with strings

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_685193b718ec832f97f359655286d4a5