### PR TITLE
Adjust logging levels and configure startup logging

### DIFF
--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -87,7 +87,7 @@ class LLMAnalyzer:
             )
             tokens = getattr(getattr(response, "usage", None), "total_tokens", None)
             if tokens is not None:
-                self.logger.debug("LLMAnalyzer tokens used: %s", tokens)
+                self.logger.info("LLMAnalyzer tokens used: %s", tokens)
             result = response.choices[0].message.content.strip()
             self.logger.debug("LLMAnalyzer._query_llm end")
             return result

--- a/Review/__init__.py
+++ b/Review/__init__.py
@@ -47,7 +47,7 @@ class Review:
             )
             tokens = getattr(getattr(response, "usage", None), "total_tokens", None)
             if tokens is not None:
-                self.logger.debug("Review tokens used: %s", tokens)
+                self.logger.info("Review tokens used: %s", tokens)
             result = response.choices[0].message.content.strip()
             self.logger.debug("Review._query_llm end")
             return result

--- a/UI/cli.py
+++ b/UI/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from pathlib import Path
 from typing import List, Optional
+import logging
 
 from GuideManager import GuideManager
 from LLMAnalyzer import LLMAnalyzer
@@ -30,6 +31,7 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
 
 def main(args: Optional[List[str]] = None) -> None:
     """Run the CLI application."""
+    logging.basicConfig(level=logging.INFO)
     options = parse_args(args)
 
     complaint = options.complaint or input("Complaint text: ")

--- a/run_app.py
+++ b/run_app.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from dotenv import load_dotenv
+import logging
 
 from UI import run_streamlit
 
 def main() -> None:
     """Execute the Streamlit UI."""
+    logging.basicConfig(level=logging.INFO)
     load_dotenv()
     run_streamlit()
 

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -114,7 +114,7 @@ class LLMAnalyzerTest(unittest.TestCase):
         self.assertEqual(result, "ok")
         messages = "\n".join(log.output)
         self.assertIn("LLMAnalyzer._query_llm start", messages)
-        self.assertIn("LLMAnalyzer tokens used: 5", messages)
+        self.assertIn("INFO:LLMAnalyzer:LLMAnalyzer tokens used: 5", messages)
         self.assertIn("LLMAnalyzer._query_llm end", messages)
 
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -61,7 +61,7 @@ class ReviewTest(unittest.TestCase):
         self.assertEqual(result, "rev")
         messages = "\n".join(log.output)
         self.assertIn("Review._query_llm start", messages)
-        self.assertIn("Review tokens used: 3", messages)
+        self.assertIn("INFO:Review:Review tokens used: 3", messages)
         self.assertIn("Review._query_llm end", messages)
 
 


### PR DESCRIPTION
## Summary
- raise logging level for token usage to INFO in `LLMAnalyzer` and `Review`
- configure logging in CLI and `run_app`
- adapt unit tests for new logging level

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685197fa8dd8832f855fda3006cfe924