### PR TITLE
Enhance Streamlit UI layout

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -11,18 +11,43 @@ from LLMAnalyzer import LLMAnalyzer
 from ReportGenerator import ReportGenerator
 from Review import Review
 
+st.set_page_config(
+    page_title="Quality Reporter",
+    page_icon=":memo:",
+    layout="centered",
+)
+
+st.markdown(
+    """
+    <style>
+        h1 {
+            color: #4E79A7;
+        }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 METHODS = ["8D", "5N1K", "A3", "DMAIC", "Ishikawa"]
 
 
 def main() -> None:
     """Run the Streamlit application."""
-    st.title("Quality Reporter")
 
-    complaint = st.text_area("Complaint")
-    method = st.selectbox("Method", METHODS)
-    customer = st.text_input("Customer")
-    subject = st.text_input("Subject")
-    part_code = st.text_input("Part code")
+    st.title("Quality Reporter")
+    st.markdown("---")
+
+    col1, col2 = st.columns(2)
+    col1.markdown("### Details")
+    complaint = col1.text_area("Complaint")
+    method = col1.selectbox("Method", METHODS)
+
+    col2.markdown("### Meta")
+    customer = col2.text_input("Customer")
+    subject = col2.text_input("Subject")
+    part_code = col2.text_input("Part code")
+
+    st.markdown("---")
 
     if st.button("Analyze"):
         manager = GuideManager()
@@ -75,12 +100,17 @@ def main() -> None:
             st.write("No final report available.")
 
         pdf_name = Path(paths["pdf"]).name
-        with open(paths["pdf"], "rb") as pdf_file:
-            st.download_button("Download PDF", pdf_file, file_name=pdf_name)
-
         excel_name = Path(paths["excel"]).name
+
+        col_dl1, col_dl2 = st.columns(2)
+        with open(paths["pdf"], "rb") as pdf_file:
+            col_dl1.download_button("Download PDF", pdf_file, file_name=pdf_name)
         with open(paths["excel"], "rb") as excel_file:
-            st.download_button("Download Excel", excel_file, file_name=excel_name)
+            col_dl2.download_button(
+                "Download Excel",
+                excel_file,
+                file_name=excel_name,
+            )
 
         st.markdown(f"[PDF file]({paths['pdf']})")
         st.markdown(f"[Excel file]({paths['excel']})")

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -14,6 +14,7 @@ class StreamlitAppTest(unittest.TestCase):
     def setUp(self) -> None:
         dummy_st = types.ModuleType("streamlit")
         dummy_st.title = MagicMock()
+        dummy_st.set_page_config = MagicMock()
         dummy_st.text_area = MagicMock(return_value="c")
         dummy_st.selectbox = MagicMock(return_value="8D")
         dummy_st.text_input = MagicMock(side_effect=["cust", "subject", "code"])
@@ -22,6 +23,11 @@ class StreamlitAppTest(unittest.TestCase):
         dummy_st.json = MagicMock()
         dummy_st.download_button = MagicMock()
         dummy_st.markdown = MagicMock()
+
+        def columns(num: int):
+            return [dummy_st for _ in range(num)]
+
+        dummy_st.columns = MagicMock(side_effect=columns)
 
         @contextmanager
         def spinner(*args, **kwargs):
@@ -53,6 +59,9 @@ class StreamlitAppTest(unittest.TestCase):
             }
 
             module.main()
+
+            self.dummy_st.set_page_config.assert_called_once()
+            self.dummy_st.columns.assert_called()
 
             m_open.assert_any_call(Path("reports") / "LLM1.txt", "w", encoding="utf-8")
             m_open.assert_any_call(Path("reports") / "LLM2.txt", "w", encoding="utf-8")


### PR DESCRIPTION
## Summary
- set Streamlit page configuration and custom CSS styling
- organize main inputs into columns with Markdown separators
- use columns for download buttons
- adjust Streamlit UI tests for new functions

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68519902e2b8832fbb076632d9fc342c