### PR TITLE
Remove file link markdown from Streamlit app

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -112,8 +112,6 @@ def main() -> None:
                 file_name=excel_name,
             )
 
-        st.markdown(f"[PDF file]({paths['pdf']})")
-        st.markdown(f"[Excel file]({paths['excel']})")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- trim redundant markdown links for generated PDF and Excel files

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68519cfc989c832fa7016a288a4fb1e1