### PR TITLE
Update Streamlit UI with branding

### DIFF
--- a/Logo/README.md
+++ b/Logo/README.md
@@ -1,0 +1,1 @@
+Place your logo image as 'logo.png' in this directory.

--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -12,7 +12,7 @@ from ReportGenerator import ReportGenerator
 from Review import Review
 
 st.set_page_config(
-    page_title="Quality Reporter",
+    page_title="Ak\u0131ll\u0131 Kalite Raporlama Asistan\u0131",
     page_icon=":memo:",
     layout="centered",
 )
@@ -20,8 +20,26 @@ st.set_page_config(
 st.markdown(
     """
     <style>
+        body {
+            background-color: #f9f9f9;
+        }
         h1 {
             color: #4E79A7;
+        }
+        .card {
+            background-color: #ffffff;
+            padding: 1rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            margin-bottom: 1rem;
+        }
+        .stButton>button {
+            background-color: #d72638;
+            color: white;
+        }
+        .stButton>button:hover {
+            background-color: #b71c2f;
+            color: white;
         }
     </style>
     """,
@@ -34,9 +52,17 @@ METHODS = ["8D", "5N1K", "A3", "DMAIC", "Ishikawa"]
 def main() -> None:
     """Run the Streamlit application."""
 
-    st.title("Quality Reporter")
+    logo_path = Path("Logo/logo.png")
+    if logo_path.exists():
+        st.image(str(logo_path), width=60)
+    st.title("Ak\u0131ll\u0131 Kalite Raporlama Asistan\u0131")
+    st.markdown(
+        "M\u00fc\u015fteri şik\u00e2yetini girin, metod seçin ve saniyeler "
+        "içinde profesyonel bir rapor oluşturun."
+    )
     st.markdown("---")
 
+    st.markdown("<div class='card'>", unsafe_allow_html=True)
     col1, col2 = st.columns(2)
     col1.markdown("### Details")
     complaint = col1.text_area("Complaint")
@@ -46,6 +72,7 @@ def main() -> None:
     customer = col2.text_input("Customer")
     subject = col2.text_input("Subject")
     part_code = col2.text_input("Part code")
+    st.markdown("</div>", unsafe_allow_html=True)
 
     st.markdown("---")
 

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -23,6 +23,7 @@ class StreamlitAppTest(unittest.TestCase):
         dummy_st.json = MagicMock()
         dummy_st.download_button = MagicMock()
         dummy_st.markdown = MagicMock()
+        dummy_st.image = MagicMock()
 
         def columns(num: int):
             return [dummy_st for _ in range(num)]
@@ -47,7 +48,8 @@ class StreamlitAppTest(unittest.TestCase):
              patch.object(module, "LLMAnalyzer") as mock_analyzer, \
              patch.object(module, "ReportGenerator") as mock_report, \
              patch.object(module, "Review") as mock_review, \
-             patch("builtins.open", m_open):
+             patch("builtins.open", m_open), \
+             patch.object(Path, "exists", return_value=True):
             mock_manager.return_value.get_format.return_value = {"fields": []}
             mock_analyzer.return_value.analyze.return_value = {
                 "full_text": "ok"
@@ -62,6 +64,7 @@ class StreamlitAppTest(unittest.TestCase):
 
             self.dummy_st.set_page_config.assert_called_once()
             self.dummy_st.columns.assert_called()
+            self.dummy_st.image.assert_called_once_with("Logo/logo.png", width=60)
 
             m_open.assert_any_call(Path("reports") / "LLM1.txt", "w", encoding="utf-8")
             m_open.assert_any_call(Path("reports") / "LLM2.txt", "w", encoding="utf-8")


### PR DESCRIPTION
## Summary
- enhance UI with new header text and description
- apply card layout and custom styles
- show optional logo image
- update test to mock logo file
- replace binary logo with README placeholder

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_6851a96cd660832fb9683600f24a979b