### PR TITLE
Fix Streamlit launch

### DIFF
--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -1,21 +1,16 @@
 """User interface utilities."""
 
 from typing import List, Optional
+import subprocess
+from pathlib import Path
 
 
 def run_streamlit() -> None:
-    """Start the Streamlit UI."""
+    """Launch the Streamlit application via ``streamlit run``."""
     from . import streamlit_app
-    from streamlit.web import bootstrap
 
-    # ``bootstrap.run`` expects the path to the Streamlit application
-    # rather than the function object itself. Passing the path prevents
-    # ``TypeError`` issues when ``bootstrap`` tries to modify ``sys.path``.
-    # ``bootstrap.run`` expects the path to the Streamlit application and a
-    # boolean ``is_hello`` flag in recent Streamlit versions. Passing ``False``
-    # avoids ``TypeError`` issues when the underlying implementation assumes a
-    # boolean value.
-    bootstrap.run(streamlit_app.__file__, False, [], [])
+    script = Path(streamlit_app.__file__).resolve()
+    subprocess.run(["streamlit", "run", str(script)], check=True)
 
 
 def run_cli(args: Optional[List[str]] = None) -> None:


### PR DESCRIPTION
## Summary
- launch Streamlit via subprocess instead of bootstrap
- update tests for new subprocess call

## Testing
- `python -m pip install -r requirements.txt`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6851d0c36520832f954122d04146ebcb